### PR TITLE
Add Priestess function + reorganisation of roleswap_msg.py

### DIFF
--- a/interpretation/ww_head.py
+++ b/interpretation/ww_head.py
@@ -9,7 +9,7 @@ from interpretation.check import is_command
 from main_classes import Mailbox
 from management.db import isParticipant, personal_channel, db_get, db_set, signup, emoji_to_player, channel_get, \
     is_owner, get_channel_members
-from roles_n_rules.commands import cc_goodbye
+from story_time.commands import cc_goodbye
 
 
 def todo():

--- a/story_time/roleswap_msg.py
+++ b/story_time/roleswap_msg.py
@@ -1,12 +1,20 @@
 # This file contains the explanation message whenever a player switches a role DURING  THE GAME.
+from management.db import db_get
 
-def swap_to(role):
-    if role == "Innocent":
-        return "This a DM! You have turned into an innocent."
-    if role == "Alcoholic":
-        return "Yer an eelcahalic now, -hips- matey."
-    if role == "Aura Teller":
-        return "You're a wizard, Harry."
-        return "You're a hairy wizard."
-        return "In other words,"
-            #TODO
+def undead_change(victim_id,old_role,new_role):
+    return 'You are now pretending to be innocent. You are still undead.'
+
+def to_innocent(victim_id,old_role = 'Cursed Civlian'):
+    if int(db_get(victim_id,'undead')) == 1:
+        return undead_change(victim_id,old_role,'Innocent')
+
+    msg = 'You have known your whole life that you had a curse hanging around you. You woke up with it, '
+    msg += 'you worked with it, you ate with it and you went to sleep with it.\n'
+    msg += 'However, you had a strange feeling lately. Not the strange way the curse gave you, no, more like an... '
+    msg += 'rnlighting feeling. You have slowly started to feel better and better, until at some point '
+    msg += 'the bad feeling was completely gone!\n'
+    msg += '**You have turned into an Innocent and you are no longer a Cursed Civlian. The rules remain the same, '
+    msg += 'you will just no longer turn into a wolf.**'
+
+    if old_role == 'Cursed Civilian':
+        return msg


### PR DESCRIPTION
The title already sayd it - those are the most prominent changes in this patch. The priestess function should now be a thing, and roleswap_msg.py will now get a different organisation. I felt like role changes are expected in some occasions, while they are unexpected in others. That's why the original role matters for the explanation.

For example, if somebody turns into a werewolf after having been a cursed civilian, that's not a surprise. The plot twist is huge, however, if the cult leader gets infected by the infected wolf. For such occasions, a relatively more exciting story would fit more.