### PR TITLE
Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 
 
 # Let's be honest
-**/*.* @Randium
+**/*.* @Randium @Bentechy66
 
 # the one thing he did.
 */profile.py @romangraef

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+
+
+# Let's be honest
+**/*.* @Randium
+
+# the one thing he did.
+*/profile.py @romangraef
+
+


### PR DESCRIPTION
This is by no means an extended list of code owners. I just prefilled some. They are basically automatical code review requests. As the bot grows larger i think it is a good idea to keep people working on different parts of the bot. And yes, because @Randium does nearly all the work, i think it is only fair to put him as code owner for everything. if @Bentechy66 also wants that, he can just put him behind the @Randium